### PR TITLE
Add instructions for creating DBs via Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ ACS Reports Team test project.
 - Install required engines with `nvm install`
 - Install dependencies with `npm install`
 - Run `docker-compose up -d db`
-  - Run `docker-compose exet db bin/db-setup`
+  - Run `docker-compose exec db bin/db-setup`
   - Note, the postgres instance will be attached to port `5400`
 - Run `bin/setup` to migrate your databases
   - If you are using `docker` you are good to go, otherwise fill out the details for your enviroment in `.env.json` and run the migrations again

--- a/README.md
+++ b/README.md
@@ -4,11 +4,13 @@ ACS Reports Team test project.
 
 ## Setup
 
-- Install required engines with `nvm install`.
+- Install required engines with `nvm install`
 - Install dependencies with `npm install`
-- Run `docker-compose up -d db`. The postgres instance will be attached to port 5400
-- Run `bin/setup`
-- If you are using `docker` you are good to go, otherwise fill out the details for your enviroment.
+- Run `docker-compose up -d db`
+  - Run `docker-compose exet db bin/db-setup`
+  - Note, the postgres instance will be attached to port `5400`
+- Run `bin/setup` to migrate your databases
+  - If you are using `docker` you are good to go, otherwise fill out the details for your enviroment in `.env.json` and run the migrations again
 - Run `npm run debug`
 
 Done!

--- a/bin/db-setup
+++ b/bin/db-setup
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -e
+
+if [ -z $(psql -U postgres -Atqc '\list node_exercise_dev' postgres) ]; then
+  createdb -U postgres node_exercise_dev
+fi
+if [ -z $(psql -U postgres -Atqc '\list node_exercise_test' postgres) ]; then
+  createdb -U postgres node_exercise_test
+fi

--- a/bin/dc-run
+++ b/bin/dc-run
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-set -e
-
-docker-compose build $1
-docker-compose run --rm "$@"

--- a/bin/dc-run-test
+++ b/bin/dc-run-test
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-set -e
-
-docker-compose run --rm ci npx jest --detectOpenHandles --forceExit "$@"

--- a/bin/setup
+++ b/bin/setup
@@ -2,13 +2,6 @@
 
 set -e
 
-if [[ -z $(psql -h localhost -p 5400 -U postgres -Atqc '\list node_exercise_dev' postgres) ]]; then
-  createdb -h localhost -p 5400 -U postgres node_exercise_dev
-fi
-if [[ -z $(psql -h localhost -p 5400 -U postgres -Atqc '\list node_exercise_test' postgres) ]]; then
-  createdb -h localhost -p 5400 -U postgres node_exercise_test
-fi
-
 if [ ! -f .env.json ]; then
   cp .env.sample .env.json
 fi
@@ -18,5 +11,4 @@ if [ ! -f .env ]; then
 fi
 
 npm run db:migrate
-npm run db:seed
 NODE_ENV=test npm run db:migrate

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,5 +16,7 @@ services:
 
   db:
     image: postgres:12.1
+    volumes:
+      - $PWD/bin/db-setup:/bin/db-setup
     ports:
       - '5400:5432'

--- a/docker/images/app/Dockerfile
+++ b/docker/images/app/Dockerfile
@@ -2,7 +2,7 @@ FROM mhart/alpine-node:16
 
 WORKDIR /home/node
 
-COPY package*.json .npmrc ./
+COPY package*.json ./
 RUN npm install --production
 
 COPY . .


### PR DESCRIPTION
Since some users might not have the PG client libraries/tools installed locally, we should still be able to achieve the same result using the existing Docker Postgres image.